### PR TITLE
Add file attachment api

### DIFF
--- a/src/Backlog/Space.php
+++ b/src/Backlog/Space.php
@@ -81,4 +81,16 @@ class Space
     {
         return $this->connector->get('space/diskUsage');
     }
+
+    /**
+     * Post Attachment File
+     *
+     * @param $multipart
+     * @return mixed|string
+     * @see https://developer.nulab-inc.com/docs/backlog/api/2/post-attachment-file/
+     */
+    public function postAttachment($multipart)
+    {
+        return $this->connector->postFile('space/attachment', $multipart);
+    }    
 }

--- a/src/Connector/ApiKeyConnector.php
+++ b/src/Connector/ApiKeyConnector.php
@@ -100,4 +100,19 @@ class ApiKeyConnector extends Connector
 
         return json_decode($response->getBody()->getContents());
     }
+
+    public function postFile($path, $multipart, $query_params = [], $headers = [])
+    {
+        try {
+            $response = $this->client->request('POST', $path, [
+                'headers' => $headers,
+                'query' => ['apiKey' => $this->api_key] + $query_params,
+                'multipart' => $multipart
+            ]);
+        } catch (\Exception $exception) {
+            throw new BacklogException($exception->getMessage(), $exception->getCode(), $exception->getPrevious());
+        }
+
+        return json_decode($response->getBody()->getContents());
+    }    
 }

--- a/src/Connector/ConnectorInterface.php
+++ b/src/Connector/ConnectorInterface.php
@@ -63,4 +63,6 @@ interface ConnectorInterface
      * @return mixed|string
      */
     public function delete($path, $form_params = [], $query_params = [], $headers = []);
+
+    public function postFile($path, $multipart, $query_params = [], $headers = []);
 }


### PR DESCRIPTION
This PR allows attaching files to backlog space.

The `$multipart` should be set as-

```
$multipart = [
    [
        'name'     => 'file',
        'contents' => fopen('test.txt', 'r'),
        'filename' => 'file name',
        'headers'  => [
            'Content-Type' => 'application/octet-stream'
        ]
    ]
]
```

I'm using your library for one of my projects. This option is really needed for me. 
