### PR TITLE
Added support for selecting API URL

### DIFF
--- a/src/Connector/ApiKeyConnector.php
+++ b/src/Connector/ApiKeyConnector.php
@@ -13,10 +13,10 @@ class ApiKeyConnector extends Connector
     /** @var string */
     protected $api_key;
 
-    public function __construct($space_id, $api_key)
+    public function __construct($space_id, $api_key, $domain = 'jp')
     {
         $this->client = new Client([
-            'base_uri' => sprintf(self::API_URL, $space_id)
+            'base_uri' => sprintf(self::API_URL, $space_id, $domain)
         ]);
 
         $this->api_key = $api_key;

--- a/src/Connector/Connector.php
+++ b/src/Connector/Connector.php
@@ -4,5 +4,5 @@ namespace Itigoppo\BacklogApi\Connector;
 
 abstract class Connector implements ConnectorInterface
 {
-    const API_URL = 'https://%s.backlog.jp/api/v2/';
+    const API_URL = 'https://%1$s.backlog.%2$s/api/v2/';
 }


### PR DESCRIPTION
# やったこと
- 下記のissueにもなっているbacklogのAPIのdomainを選択出来るように変更
  - https://github.com/itigoppo/backlog-api/issues/4
- 既存の利用者を考慮してdefaultは `jp`