### PR TITLE
Api/issue attachment

### DIFF
--- a/src/Backlog/Issues.php
+++ b/src/Backlog/Issues.php
@@ -249,6 +249,19 @@ class Issues
     }
 
     /**
+     * Get Issue Attachment
+     * @api https://developer.nulab.com/docs/backlog/api/2/get-issue-attachment/
+     *
+     * @param string $issues_id_or_key
+     * @param string $attachment_id
+     * @return \GuzzleHttp\Psr7\Response
+     */
+    public function attachment($issues_id_or_key, $attachment_id)
+    {
+        return $this->connector->getFile(sprintf('issues/%s/attachments/%s', $issues_id_or_key, $attachment_id));
+    }
+
+    /**
      * 課題共有ファイル一覧の取得
      *
      * @param string $issues_id_or_key

--- a/src/Connector/ApiKeyConnector.php
+++ b/src/Connector/ApiKeyConnector.php
@@ -115,4 +115,24 @@ class ApiKeyConnector extends Connector
 
         return json_decode($response->getBody()->getContents());
     }
+
+    public function getFile($path, $form_params = [], $query_params = [], $headers = [])
+    {
+        try {
+            $response = $this->client->request('GET', $path, [
+                'headers' => $headers,
+                'query' => ['apiKey' => $this->api_key] + $query_params,
+                'form_params' => $form_params,
+            ]);
+        } catch (\Exception $exception) {
+            throw new BacklogException($exception->getMessage(), $exception->getCode(), $exception->getPrevious());
+        }
+
+        if ($response->getStatusCode() != '200') {
+            throw new BacklogException('', $response->getStatusCode());
+        }
+
+        // Return the whole response object for further processing
+        return $response;
+    }
 }

--- a/src/Connector/ConnectorInterface.php
+++ b/src/Connector/ConnectorInterface.php
@@ -74,4 +74,15 @@ interface ConnectorInterface
      * @return mixed
      */
     public function postFile($path, $multipart, $query_params = [], $headers = []);
+
+    /**
+     * Get Request for File
+     *
+     * @param string $path
+     * @param array $form_params
+     * @param array $query_params
+     * @param array $headers
+     * @return \GuzzleHttp\Psr7\Response
+     */
+    public function getFile($path, $form_params = [], $query_params = [], $headers = []);
 }

--- a/src/Connector/OAuthConnector.php
+++ b/src/Connector/OAuthConnector.php
@@ -29,4 +29,14 @@ class OAuthConnector extends Connector
     {
         // TODO: Implement delete() method.
     }
+
+    public function postFile($path, $multipart, $query_params = [], $headers = [])
+    {
+        // TODO: Implement postFile() method.
+    }
+
+    public function getFile($path, $form_params = [], $query_params = [], $headers = [])
+    {
+        // TODO: Implement getFile() method.
+    }
 }


### PR DESCRIPTION
Backlog has updated their api.
One of the useful api is `Get Issue Attachment`
https://developer.nulab.com/docs/backlog/api/2/get-issue-attachment/

I've added that one.
I had to add a new method `getFile`, as the `get` method returns the content only.
To download/process the file we need headers and body both. That's why the `getFile` method returns the whole response object.