### PR TITLE
Allow Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Backlog API Library for PHP",
     "type": "library",
     "require": {
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3 || ~7"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.1",


### PR DESCRIPTION
This PR allows Guzzle 7 as a dependency, while maintaining Guzzle 6 as a valid option.

Drupal 10 (relased 2022-12-14) requires:

| Package                 | Version | Requirement                |
| ----------------------- | ------- | -------------------------- |
| drupal/core             | 10.0.0  | guzzlehttp/guzzle (^7.5)   |
| drupal/core-recommended | 10.0.0  | guzzlehttp/guzzle (~7.5.0) |